### PR TITLE
feat: terminal-style homepage hero with interactive CLI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ social-network-links:
   twitter: magichuihui
   patreon: magichuihui
   youtube: "@magichuihui"
-  whatsapp: 15551212
+  # whatsapp: yourphonenumber
 #  medium: yourname
 #  reddit: yourname or r/yoursubreddit
 #  linkedin: magichuihui
@@ -127,7 +127,7 @@ edit_page_button: true
 navbar-var-length: false
 
 # The keywords to associate with your website, for SEO purposes
-#keywords: "my,list,of,keywords"
+keywords: "DevOps, Kubernetes, Cloud Native, OpenWRT, Infrastructure, SRE, Linux, Vault, Terraform"
 
 ######################################
 # --- Colours / background image --- #
@@ -259,7 +259,7 @@ date_format: "%B %-d, %Y"
 #################################################################################
 
 # Output options (more information on Jekyll's site)
-timezone: "America/Toronto"
+timezone: "Asia/Shanghai"
 markdown: kramdown
 highlighter: rouge
 permalink: /:year-:month-:day-:title/

--- a/_includes/terminal-hero.html
+++ b/_includes/terminal-hero.html
@@ -1,0 +1,25 @@
+<div class="terminal-wrapper">
+  <div class="terminal-titlebar">
+    <div class="terminal-dots">
+      <span class="terminal-dot red"></span>
+      <span class="terminal-dot amber"></span>
+      <span class="terminal-dot green"></span>
+    </div>
+    <span class="terminal-title">guest@kyraos:~/home — bash</span>
+  </div>
+  <div id="terminal-screen" class="terminal-screen">
+    <div class="terminal-line dim">Starting terminal...</div>
+  </div>
+  <div class="terminal-input-line" id="terminal-input-line">
+    <span class="terminal-prompt">guest@kyraos:~$</span>
+    <input type="text" id="terminal-input" class="terminal-input" autofocus spellcheck="false" autocomplete="off" aria-label="Terminal input" />
+  </div>
+</div>
+
+<script>
+window._terminalPosts = [
+  {% for post in site.posts limit:20 %}
+  { title: {{ post.title | jsonify }}, url: {{ post.url | relative_url | jsonify }}, date: {{ post.date | date: "%Y-%m-%d" | jsonify }} }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+];
+</script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,6 +4,10 @@ layout: page
 
 {{ content }}
 
+{% if page.terminal-hero %}
+  {% include terminal-hero.html %}
+{% endif %}
+
 {% assign posts = paginator.posts | default: site.posts %}
 
 <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->

--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -1,0 +1,251 @@
+/* Terminal Hero Theme - Tokyo Night inspired */
+:root {
+  --terminal-bg: #0d1117;
+  --terminal-text: #c9d1d9;
+  --terminal-green: #7ec699;
+  --terminal-amber: #d4a84b;
+  --terminal-red: #f7768e;
+  --terminal-blue: #7aa2f7;
+  --terminal-purple: #bb9af7;
+  --terminal-cyan: #7dcfff;
+  --terminal-comment: #565f89;
+  --terminal-prompt: #98c379;
+  --terminal-title-bg: #1c2333;
+  --terminal-title-text: #abb2bf;
+  --terminal-border: #2c3e50;
+  --terminal-cursor: #7ec699;
+}
+
+.terminal-wrapper {
+  margin: 1.5rem 0 2.5rem;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.5);
+  border: 1px solid var(--terminal-border);
+}
+
+/* Title bar */
+.terminal-titlebar {
+  background: var(--terminal-title-bg);
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+  border-bottom: 1px solid var(--terminal-border);
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 7px;
+}
+
+.terminal-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.terminal-dot.red { background: #ff5f56; }
+.terminal-dot.amber { background: #ffbd2e; }
+.terminal-dot.green { background: #27c93f; }
+
+.terminal-title {
+  color: var(--terminal-title-text);
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Fira Code", "Courier New", monospace;
+  font-size: 0.8rem;
+  margin: 0 auto;
+  opacity: 0.8;
+}
+
+/* Terminal screen */
+.terminal-screen {
+  background: var(--terminal-bg);
+  padding: 16px;
+  min-height: 320px;
+  max-height: 480px;
+  overflow-y: auto;
+  font-family: "SF Mono", Monaco, "Cascadia Code", "Fira Code", "Courier New", monospace;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--terminal-text);
+  scrollbar-width: thin;
+  scrollbar-color: var(--terminal-border) transparent;
+}
+
+.terminal-screen::-webkit-scrollbar {
+  width: 6px;
+}
+
+.terminal-screen::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.terminal-screen::-webkit-scrollbar-thumb {
+  background: var(--terminal-border);
+  border-radius: 3px;
+}
+
+/* Output lines */
+.terminal-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+  min-height: 1.25em;
+}
+
+.terminal-line.green { color: var(--terminal-green); }
+.terminal-line.amber { color: var(--terminal-amber); }
+.terminal-line.red { color: var(--terminal-red); }
+.terminal-line.blue { color: var(--terminal-blue); }
+.terminal-line.purple { color: var(--terminal-purple); }
+.terminal-line.cyan { color: var(--terminal-cyan); }
+.terminal-line.comment { color: var(--terminal-comment); }
+.terminal-line.bold { font-weight: 700; }
+.terminal-line.dim { opacity: 0.7; }
+
+/* Input line */
+.terminal-input-line {
+  display: flex;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.terminal-prompt {
+  color: var(--terminal-prompt);
+  margin-right: 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.terminal-input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--terminal-text);
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  flex: 1;
+  caret-color: var(--terminal-cursor);
+  padding: 0;
+  margin: 0;
+}
+
+/* Cursor blink for non-input prompts */
+.terminal-cursor {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.1em;
+  background: var(--terminal-cursor);
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ASCII art */
+.terminal-ascii {
+  color: var(--terminal-purple);
+  line-height: 1.2;
+  font-size: 0.75rem;
+  white-space: pre;
+}
+
+/* Command output tables */
+.terminal-table {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 16px;
+  margin: 4px 0;
+}
+
+.terminal-table .key {
+  color: var(--terminal-cyan);
+}
+
+.terminal-table .value {
+  color: var(--terminal-text);
+}
+
+/* Help command grid */
+.terminal-help-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 24px;
+  margin: 4px 0;
+}
+
+.terminal-help-grid .cmd {
+  color: var(--terminal-green);
+  font-weight: 600;
+}
+
+.terminal-help-grid .desc {
+  color: var(--terminal-comment);
+}
+
+/* Post entries */
+.terminal-post-entry {
+  padding: 3px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+}
+
+.terminal-post-entry:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.terminal-post-title {
+  color: var(--terminal-blue);
+  text-decoration: none;
+}
+
+.terminal-post-title:hover {
+  color: var(--terminal-cyan);
+  text-decoration: underline;
+}
+
+.terminal-post-date {
+  color: var(--terminal-comment);
+  font-size: 0.78rem;
+  margin-left: 8px;
+}
+
+/* "Kernel" boot messages */
+.terminal-boot-msg {
+  color: var(--terminal-comment);
+}
+
+.terminal-boot-msg .boot-ok {
+  color: var(--terminal-green);
+}
+
+.terminal-boot-msg .boot-info {
+  color: var(--terminal-blue);
+}
+
+.terminal-boot-msg .boot-warn {
+  color: var(--terminal-amber);
+}
+
+/* Responsive */
+@media (max-width: 576px) {
+  .terminal-screen {
+    min-height: 260px;
+    max-height: 380px;
+    padding: 12px;
+    font-size: 0.78rem;
+  }
+
+  .terminal-ascii {
+    font-size: 0.55rem;
+  }
+
+  .terminal-title {
+    font-size: 0.7rem;
+  }
+}

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1,0 +1,498 @@
+(function () {
+  'use strict';
+
+  var term = {
+    screen: null,
+    input: null,
+    history: [],
+    historyIndex: -1,
+    commands: {},
+    buffer: [],
+    booting: true,
+    posts: []
+  };
+
+  var ASCII_BANNER = [
+    '%cpurple%  ██╗  ██╗██╗   ██╗██████╗  █████╗ ',
+    '%cpurple%  ██║ ██╔╝╚██╗ ██╔╝██╔══██╗██╔══██╗',
+    '%cpurple%  █████╔╝  ╚████╔╝ ██████╔╝███████║',
+    '%cpurple%  ██╔═██╗   ╚██╔╝  ██╔══██╗██╔══██║',
+    '%cpurple%  ██║  ██╗   ██║   ██║  ██║██║  ██║',
+    '%cpurple%  ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝',
+    ''
+  ];
+
+  var BOOT_MESSAGES = [
+    { text: ' Booting KyraOS v1.0.0 ...', cls: 'boot-ok' },
+    { text: ' [  OK  ] Loaded kernel module: kyra_core', cls: 'boot-ok' },
+    { text: ' [  OK  ] Initialized networking stack', cls: 'boot-ok' },
+    { text: ' [  OK  ] Mounted /home filesystem', cls: 'boot-ok' },
+    { text: ' [  OK  ] Started blog engine (Jekyll)', cls: 'boot-ok' },
+    { text: ' [  OK  ] Loaded ' + (window._terminalPosts ? window._terminalPosts.length : 0) + ' blog posts', cls: 'boot-ok' },
+    { text: ' [  OK  ] Ready on port 443', cls: 'boot-ok' },
+    { text: '', cls: '' }
+  ];
+
+  var SKILLS = [
+    { key: 'Kubernetes', value: 'Cluster ops, Helm, Istio, Calico, ArgoCD' },
+    { key: 'CI/CD', value: 'GitHub Actions, GitLab CI, ArgoCD, Jenkins' },
+    { key: 'Infra as Code', value: 'Terraform, Helm, Ansible' },
+    { key: 'Security', value: 'Vault, Let\'s Encrypt, mTLS, OIDC' },
+    { key: 'Networking', value: 'OpenWRT, Calico, BGP, nftables' },
+    { key: 'Storage', value: 'Ceph, Rook, Longhorn' },
+    { key: 'Observability', value: 'Elasticsearch, Prometheus, Grafana' },
+    { key: 'Languages', value: 'Go, Python, Bash, Lua' }
+  ];
+
+  var CONTACT = [
+    { key: 'GitHub', value: 'github.com/magichuihui' },
+    { key: 'Blog', value: 'blog.amyinfo.com' }
+  ];
+
+  var ABOUT_TEXT = [
+    'Infrastructure & Platform Engineer. I write about Kubernetes,',
+    'cloud-native technologies, networking, and infrastructure automation.',
+    '',
+    'This site is a collection of notes, guides, and hard-won lessons',
+    'from running production systems.'
+  ];
+
+  var WHOAMI_TEXT = [
+    'Login: magichuihui',
+    'Name: Kyra',
+    'Shell: /bin/bash',
+    'Home: /home/kyra',
+    'Site: blog.amyinfo.com',
+    'Uptime: varies',
+    'VM: walking on clouds (and bare metal)'
+  ];
+
+  var UPTIME_JOKES = [
+    'up ' + Math.floor(Math.random() * 365 + 1) + ' days, ' + Math.floor(Math.random() * 24) + ' hours (since last existential crisis)',
+    'up ' + Math.floor(Math.random() * 99 + 1) + ' days — kernel panics: 0, caffeine crashes: ' + Math.floor(Math.random() * 42 + 1),
+    'up way too long, should probably reboot soon (famous last words)'
+  ];
+
+  function init() {
+    term.screen = document.getElementById('terminal-screen');
+    term.input = document.getElementById('terminal-input');
+    term.posts = window._terminalPosts || [];
+
+    registerCommands();
+    bindEvents();
+    bootSequence();
+  }
+
+  function registerCommands() {
+    addCommand('help', cmdHelp, 'Show this help message');
+    addCommand('ls', cmdPosts, 'List recent blog posts');
+    addCommand('posts', cmdPosts, 'Alias for ls');
+    addCommand('about', cmdAbout, 'About this site');
+    addCommand('skills', cmdSkills, 'Show tech stack');
+    addCommand('whoami', cmdWhoami, 'Display user info');
+    addCommand('neofetch', cmdNeofetch, 'Display system info');
+    addCommand('contact', cmdContact, 'Show contact info');
+    addCommand('banner', cmdBanner, 'Display the startup banner');
+    addCommand('clear', cmdClear, 'Clear the terminal');
+    addCommand('date', cmdDate, 'Show current date/time');
+    addCommand('uptime', cmdUptime, 'Show system uptime');
+    addCommand('history', cmdHistory, 'Show command history');
+    addCommand('github', cmdGithub, 'Open GitHub profile');
+    addCommand('repo', cmdRepo, 'Open site source code');
+    addCommand('echo', cmdEcho, 'Echo the input text');
+    addCommand('uname', cmdUname, 'Print system information');
+  }
+
+  function addCommand(name, fn, description) {
+    term.commands[name] = { fn: fn, desc: description };
+  }
+
+  function bindEvents() {
+    term.input.addEventListener('keydown', function (e) {
+      if (term.booting) return;
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        var cmd = term.input.value.trim();
+        processCommand(cmd);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        navigateHistory(-1);
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        navigateHistory(1);
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        doTabCompletion();
+      }
+    });
+
+    term.screen.addEventListener('click', function () {
+      if (!term.booting) term.input.focus();
+    });
+  }
+
+  function bootSequence() {
+    term.booting = true;
+    term.input.disabled = true;
+    var inputLine = document.getElementById('terminal-input-line');
+    if (inputLine) inputLine.style.display = 'none';
+
+    var lines = [];
+
+    // Boot messages
+    BOOT_MESSAGES.forEach(function (msg) {
+      lines.push({ text: msg.text, cls: msg.cls, delay: 60 });
+    });
+
+    // ASCII banner
+    ASCII_BANNER.forEach(function (line) {
+      lines.push({ text: line, cls: 'ascii', delay: 20 });
+    });
+
+    // Welcome line
+    lines.push({ text: 'Welcome to Kyra\'s home — blog.amyinfo.com', cls: 'green bold', delay: 80 });
+    lines.push({ text: 'Type \'help\' for available commands.', cls: 'dim', delay: 60 });
+    lines.push({ text: '', cls: '', delay: 40 });
+
+    typeLines(lines, 0, function () {
+      term.booting = false;
+      term.input.disabled = false;
+      var inputLine = document.getElementById('terminal-input-line');
+      if (inputLine) inputLine.style.display = '';
+      term.input.focus();
+      showPrompt();
+    });
+  }
+
+  function typeLines(lines, index, callback) {
+    if (index >= lines.length) {
+      if (callback) callback();
+      return;
+    }
+
+    var line = lines[index];
+    addOutput(line.text, line.cls, line.delay > 0);
+
+    if (line.delay > 0) {
+      setTimeout(function () {
+        typeLines(lines, index + 1, callback);
+      }, line.delay);
+    } else {
+      typeLines(lines, index + 1, callback);
+    }
+  }
+
+  function addOutput(text, cls, animated) {
+    if (!text && text !== '') return;
+
+    var line = document.createElement('div');
+    line.className = 'terminal-line' + (cls ? ' ' + cls : '');
+
+    if (animated) {
+      line.textContent = '';
+      term.screen.appendChild(line);
+      typeText(line, text, 0, 8);
+    } else {
+      if (cls === 'ascii') {
+        line.className = 'terminal-line terminal-ascii';
+        line.textContent = text;
+      } else {
+        line.textContent = text;
+      }
+      term.screen.appendChild(line);
+    }
+
+    scrollToBottom();
+  }
+
+  function typeText(element, text, index, speed) {
+    if (index < text.length) {
+      element.textContent += text[index];
+      scrollToBottom();
+      setTimeout(function () {
+        typeText(element, text, index + 1, speed);
+      }, speed);
+    }
+  }
+
+  function scrollToBottom() {
+    term.screen.scrollTop = term.screen.scrollHeight;
+  }
+
+  function showPrompt() {
+    var promptEl = document.querySelector('.terminal-prompt');
+    if (promptEl) {
+      promptEl.textContent = 'guest@kyraos:~$';
+    }
+  }
+
+  function processCommand(input) {
+    if (!input) {
+      renderPromptLine(input, '');
+      return;
+    }
+
+    term.history.push(input);
+    term.historyIndex = term.history.length;
+
+    var parts = input.split(/\s+/);
+    var cmdName = parts[0].toLowerCase();
+    var args = parts.slice(1).join(' ');
+
+    var cmd = term.commands[cmdName];
+
+    if (cmd) {
+      renderPromptLine(input, '');
+      cmd.fn(args);
+    } else {
+      renderPromptLine(input, '');
+      addOutput(input + ': command not found', 'red');
+      addOutput('Type \'help\' for available commands.', 'dim');
+    }
+
+    term.input.value = '';
+    scrollToBottom();
+  }
+
+  function renderPromptLine(input, output) {
+    var line = document.createElement('div');
+    line.className = 'terminal-line';
+    line.innerHTML = '<span class="terminal-prompt-inline" style="color:var(--terminal-prompt)">guest@kyraos:~$</span> '
+      + escapeHtml(input);
+    term.screen.appendChild(line);
+  }
+
+  function navigateHistory(direction) {
+    if (term.history.length === 0) return;
+
+    term.historyIndex += direction;
+
+    if (term.historyIndex < 0) {
+      term.historyIndex = -1;
+      term.input.value = '';
+      return;
+    }
+
+    if (term.historyIndex >= term.history.length) {
+      term.historyIndex = term.history.length;
+      term.input.value = '';
+      return;
+    }
+
+    term.input.value = term.history[term.historyIndex];
+    // Move cursor to end
+    setTimeout(function () {
+      term.input.selectionStart = term.input.selectionEnd = term.input.value.length;
+    }, 0);
+  }
+
+  function doTabCompletion() {
+    var input = term.input.value.trim();
+    if (!input) return;
+
+    var parts = input.split(/\s+/);
+    var partial = parts[0].toLowerCase();
+
+    var matches = Object.keys(term.commands).filter(function (cmd) {
+      return cmd.indexOf(partial) === 0;
+    });
+
+    if (matches.length === 1) {
+      var rest = parts.slice(1).join(' ');
+      term.input.value = matches[0] + (rest ? ' ' + rest : ' ');
+    } else if (matches.length > 1) {
+      renderPromptLine(term.input.value, '');
+      addOutput(matches.join('  '), 'comment');
+    }
+  }
+
+  // ========== COMMAND HANDLERS ==========
+
+  function cmdHelp() {
+    addOutput('Available commands:', 'green bold');
+    addOutput('');
+
+    var cmdNames = Object.keys(term.commands).sort();
+
+    cmdNames.forEach(function (name) {
+      var cmd = term.commands[name];
+      if (name === 'posts') return;
+      var desc = cmd.desc || '';
+      addOutput('  ' + padRight(name, 12) + '  ' + desc);
+    });
+
+    addOutput('');
+    addOutput('Tab completion available.', 'dim');
+  }
+
+  function cmdPosts() {
+    if (term.posts.length === 0) {
+      addOutput('No posts found.', 'amber');
+      return;
+    }
+
+    addOutput('Recent posts:', 'green bold');
+    addOutput('');
+
+    term.posts.forEach(function (post, i) {
+      var num = String(i + 1);
+      var title = post.title;
+      var date = post.date || '';
+      var url = post.url || '#';
+      var lineEl = document.createElement('div');
+      lineEl.className = 'terminal-line terminal-post-entry';
+      lineEl.innerHTML = '<span style="color:var(--terminal-comment)">' + padRight(num, 3) + '</span>'
+        + '<a class="terminal-post-title" href="' + url + '">' + escapeHtml(title) + '</a>'
+        + '<span class="terminal-post-date">' + date + '</span>';
+      term.screen.appendChild(lineEl);
+    });
+
+    addOutput('');
+    addOutput('Click a post to read it, or visit the blog feed below.', 'dim');
+  }
+
+  function cmdAbout() {
+    addOutput('About', 'green bold');
+    addOutput('');
+    ABOUT_TEXT.forEach(function (line) {
+      addOutput(line);
+    });
+  }
+
+  function cmdSkills() {
+    addOutput('Skills & Technologies', 'green bold');
+    addOutput('');
+    SKILLS.forEach(function (s) {
+      addOutput('  ' + padRight(s.key, 18) + s.value);
+    });
+  }
+
+  function cmdWhoami() {
+    addOutput('');
+    WHOAMI_TEXT.forEach(function (line) {
+      addOutput(line);
+    });
+    addOutput('');
+  }
+
+  function cmdNeofetch() {
+    addOutput('');
+    addOutput('          .-\'`' + padRight('`' + '`' + '\'-.', 30), 'amber');
+    addOutput('        .\'  ' + '   ' + '    `'.replace(/\s+/, ' '), 'amber');
+    addOutput('       /    ' + 'KyraOS' + '    \\', 'amber');
+    addOutput('      ;    ' + 'v1.0.0' + '     ;', 'amber');
+    addOutput('      |              |', 'amber');
+    addOutput('      ;              ;', 'amber');
+    addOutput('       \\            /', 'amber');
+    addOutput('        `.        .\'', 'amber');
+    addOutput('          `-...-\'', 'amber');
+    addOutput('');
+    addOutput('  ' + padRight('Host', 14) + 'Kyra\'s home', 'cyan');
+    addOutput('  ' + padRight('Kernel', 14) + 'KyraOS v1.0.0', 'cyan');
+    addOutput('  ' + padRight('Shell', 14) + '/bin/bash', 'cyan');
+    addOutput('  ' + padRight('Posts', 14) + term.posts.length + ' articles', 'cyan');
+    addOutput('  ' + padRight('Uptime', 14) + 'long enough', 'cyan');
+    addOutput('');
+  }
+
+  function cmdContact() {
+    addOutput('Contact', 'green bold');
+    addOutput('');
+    CONTACT.forEach(function (c) {
+      addOutput('  ' + padRight(c.key, 12) + c.value);
+    });
+    addOutput('');
+    addOutput('I\'m also active on the Fediverse & various Kubernetes communities.', 'dim');
+  }
+
+  function cmdBanner() {
+    addOutput('');
+    ASCII_BANNER.forEach(function (line) {
+      if (line) {
+        var el = document.createElement('div');
+        el.className = 'terminal-line terminal-ascii';
+        el.textContent = line.replace(/%c\w+%/g, '');
+        term.screen.appendChild(el);
+      } else {
+        addOutput('');
+      }
+    });
+    addOutput('Welcome back!', 'green');
+  }
+
+  function cmdClear() {
+    term.screen.innerHTML = '';
+    term.input.value = '';
+    term.input.focus();
+  }
+
+  function cmdDate() {
+    var now = new Date();
+    addOutput(now.toString(), 'green');
+  }
+
+  function cmdUptime() {
+    var joke = UPTIME_JOKES[Math.floor(Math.random() * UPTIME_JOKES.length)];
+    addOutput(' ' + joke, 'amber');
+  }
+
+  function cmdHistory() {
+    if (term.history.length === 0) {
+      addOutput('No commands in history.', 'dim');
+      return;
+    }
+
+    addOutput('');
+    term.history.forEach(function (cmd, i) {
+      addOutput('  ' + String(i + 1) + '  ' + cmd);
+    });
+    addOutput('');
+  }
+
+  function cmdGithub() {
+    addOutput('Opening GitHub profile...', 'green');
+    addOutput('https://github.com/magichuihui', 'blue');
+    window.open('https://github.com/magichuihui', '_blank');
+  }
+
+  function cmdRepo() {
+    addOutput('Opening source code...', 'green');
+    addOutput('https://github.com/magichuihui/magichuihui.github.io', 'blue');
+    window.open('https://github.com/magichuihui/magichuihui.github.io', '_blank');
+  }
+
+  function cmdEcho(args) {
+    if (args) {
+      addOutput(args, 'green');
+    }
+  }
+
+  function cmdUname() {
+    addOutput('KyraOS kyra-blog 6.8.0-kyra #1 SMP PREEMPT_DYNAMIC x86_64 GNU/Linux', 'green');
+  }
+
+  // ========== UTILITIES ==========
+
+  function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  function padRight(str, len) {
+    str = String(str);
+    while (str.length < len) {
+      str += ' ';
+    }
+    return str;
+  }
+
+  // Initialize on DOM ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+})();

--- a/index.html
+++ b/index.html
@@ -1,5 +1,10 @@
 ---
 layout: home
 title: Blog
-subtitle: This is where I will tell my friends way too much about me
+subtitle: DevOps & Cloud Native Engineering — notes from the field
+terminal-hero: true
+css:
+  - "/assets/css/terminal.css"
+js:
+  - "/assets/js/terminal.js"
 ---


### PR DESCRIPTION
## Summary
- Add interactive terminal-styled hero section to the homepage
- Terminal features boot animation, 17 CLI commands, command history, tab completion
- Keeps existing blog feed below the terminal

## Changes
### New files
- `_includes/terminal-hero.html` — Terminal HTML structure with Jekyll data embedding
- `assets/css/terminal.css` — Tokyo Night terminal theme
- `assets/js/terminal.js` — CLI engine with command processing

### Modified files
- `index.html` — New subtitle, terminal flag, CSS/JS references
- `_layouts/home.html` — Conditional terminal hero include
- `_config.yml` — Keywords, timezone fix, security cleanup

## Commands
`help` `ls` `about` `skills` `whoami` `neofetch` `contact` `clear` `date` `uptime` `history` `github` `repo` `echo` `uname` `banner`

## Verifying
Deploy preview: https://blog.amyinfo.com (after merge and GitHub Actions build)