### PR TITLE
fix: always emit favicon link instead of conditional site.static_files

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -161,14 +161,7 @@
   <link rel="stylesheet" href="{{ "/assets/css/staticman.css" | relative_url }}">
   {% endif %}
 
-  {% assign favicon_exists = site.static_files | where: "path", "/favicon.ico" | size %}
-  {% if favicon_exists == 1 %}
-  <link rel="icon" href="{{ '/favicon.ico' | relative_url }}" />
-  {% endif %}
-  {% assign favicon_jpeg = site.static_files | where: "relative_path", "/assets/img/amyinfo.com.jpeg" | size %}
-  {% if favicon_jpeg == 1 %}
   <link rel="icon" type="image/jpeg" href="{{ '/assets/img/amyinfo.com.jpeg' | relative_url }}" />
-  {% endif %}
 
   {% if page.head-extra %}
     {% for file in page.head-extra %}


### PR DESCRIPTION
## Summary

Root cause: The favicon `<link>` tag was wrapped in a Liquid conditional that checked `site.static_files`. Jekyll's `site.static_files` filter doesn't reliably match in GitHub Pages' build environment — the tag was never emitted.

Fix: Remove the conditional entirely. The favicon JPEG file at `/assets/img/amyinfo.com.jpeg` is confirmed accessible (verified via direct fetch). Always emit the favicon link tag so the browser tab icon shows.

Changes:
- `_includes/head.html`: Replace conditional favicon block with a single unconditional `<link rel="icon" type="image/jpeg">` tag