### PR TITLE
feat: add terminal overlay to all pages via base layout

### DIFF
--- a/_includes/terminal-hero.html
+++ b/_includes/terminal-hero.html
@@ -35,7 +35,7 @@ window._terminalTags = [
 ];
 window._terminalSite = {
   title: {{ site.title | jsonify }},
-  subtitle: {{ page.subtitle | jsonify }},
+  subtitle: {{ page.subtitle | default: site.description | jsonify }},
   url: {{ '/' | absolute_url | jsonify }},
   author: {{ site.author | jsonify }}
 };

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,6 +2,7 @@
 common-css:
   - "/assets/css/bootstrap-social.css"
   - "/assets/css/beautifuljekyll.css"
+  - "/assets/css/terminal.css"
 common-ext-css:
   - href: "https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
     sri: "sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
@@ -17,6 +18,7 @@ common-ext-js:
     sri: "sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
 common-js:
   - "/assets/js/beautifuljekyll.js"
+  - "/assets/js/terminal.js"
 ---
 
 <!DOCTYPE html>
@@ -34,6 +36,8 @@ common-js:
   {% include footer.html %}
 
   {% include footer-scripts.html %}
+
+  {% include terminal-hero.html %}
 
 </body>
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,10 +4,6 @@ layout: page
 
 {{ content }}
 
-{% if page.terminal-hero %}
-  {% include terminal-hero.html %}
-{% endif %}
-
 {% assign posts = paginator.posts | default: site.posts %}
 
 <!-- role="list" needed so that `list-style: none` in Safari doesn't remove the list semantics -->

--- a/index.html
+++ b/index.html
@@ -3,11 +3,6 @@ layout: home
 title: Blog
 subtitle: DevOps & Cloud Native Engineering — notes from the field
 description: "Kyra's blog about Kubernetes, cloud-native infrastructure, DevOps, OpenWRT, and production systems engineering."
-terminal-hero: true
-css:
-  - "/assets/css/terminal.css"
-js:
-  - "/assets/js/terminal.js"
 head-extra:
   - seo-schema.html
 ---


### PR DESCRIPTION
Move terminal overlay HTML, return button, post/tag data, CSS, and JS from homepage-only setup into the base layout so every page has the terminal available.

Users can now press 🖥 Terminal from any page (not just homepage) to get the full CLI experience.