### PR TITLE
fix: keep terminal hidden on non-homepage pages, show only return button

### DIFF
--- a/_includes/terminal-hero.html
+++ b/_includes/terminal-hero.html
@@ -1,4 +1,4 @@
-<div id="terminal-overlay">
+<div id="terminal-overlay"{% if page.layout != 'home' %} class="hidden"{% endif %}>
   <div class="terminal-wrapper fullscreen">
     <div class="terminal-titlebar">
       <div class="terminal-dots">
@@ -19,7 +19,7 @@
   </div>
 </div>
 
-<button id="terminal-return-btn" class="terminal-return-btn" title="Switch to terminal mode">🖥 Terminal</button>
+<button id="terminal-return-btn" class="terminal-return-btn{% if page.layout != 'home' %} visible{% endif %}" title="Switch to terminal mode">🖥 Terminal</button>
 
 <script>
 window._terminalPosts = [

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -59,6 +59,11 @@
     registerCommands();
     bindEvents();
     bootSequence();
+
+    // Non-homepage: terminal starts hidden, undo body scroll lock
+    if (term.overlay.classList.contains('hidden')) {
+      document.body.style.overflow = '';
+    }
   }
 
   /* ===== COMMAND SYSTEM ===== */


### PR DESCRIPTION
The terminal overlay now starts hidden on non-homepage pages — only the 🖥 Terminal button is visible. Clicking it opens the terminal normally.

Homepage behavior unchanged (full-screen terminal by default).