### PR TITLE
fix: use global post indices in tag command results

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -541,22 +541,18 @@
     }
     addOutput('Posts tagged "' + args + '" (' + matching.length + '):', 'green bold');
     addOutput('');
-    matching.forEach(function (p, i) {
+    matching.forEach(function (p) {
+      var globalIdx = term.posts.indexOf(p) + 1;
       addOutputRaw(
-        '  <span class="terminal-post-idx">' + (i + 1) + '.</span>'
-        + '<a class="terminal-post-title" data-url="' + escHtml(p.url) + '">'
+        '  <span class="terminal-post-idx">' + padRight(String(globalIdx), 3) + '</span>'
+        + '<a class="terminal-post-title" data-idx="' + globalIdx + '">'
         + escHtml(p.title) + '</a>'
         + '<span class="terminal-post-date">' + (p.date || '') + '</span>'
       );
     });
-    setTimeout(function () {
-      var links = term.screen.querySelectorAll('.terminal-post-title[data-url]');
-      for (var k = 0; k < links.length; k++) {
-        links[k].addEventListener('click', function () {
-          openUrlNewTab(this.getAttribute('data-url'));
-        });
-      }
-    }, 50);
+    addOutput('');
+    addOutput('Use cat <number> to open a post, or click above.', 'dim');
+    setTimeout(bindPostClicks, 50);
   }
 
   /* ===== COMMAND: about ===== */


### PR DESCRIPTION
## Summary
- `tag <name>` was showing local indices (1, 2, 3... within the tag), making `cat <number>` open the wrong post
- Now shows global indices matching `ls` and `search`, so `cat <number>` works consistently everywhere
- Click handler updated to use `bindPostClicks` (same as `ls`/`search`)

## Changes
- `assets/js/terminal.js`: `cmdTag` now uses `term.posts.indexOf(p) + 1` for global index, `data-idx` attribute, and `bindPostClicks`