### PR TITLE
feat: random and latest show preview instead of opening directly

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -507,11 +507,19 @@
       return;
     }
     var idx = Math.floor(Math.random() * term.posts.length);
+    var p = term.posts[idx];
     if (term.pipeActive) {
       term.pipeBuffer = idx + 1;
-      addOutput('Picked #' + (idx + 1) + '...', 'green');
+      addOutput('Picked #' + (idx + 1) + ': "' + p.title + '"', 'green');
     } else {
-      openPost(term.posts[idx]);
+      addOutputRaw(
+        '  <span class="terminal-post-idx">' + padRight(String(idx + 1), 3) + '</span>'
+        + '<a class="terminal-post-title" data-idx="' + (idx + 1) + '">' + escHtml(p.title) + '</a>'
+        + '<span class="terminal-post-date">' + (p.date || '') + '</span>',
+        'green bold'
+      );
+      addOutput('Use cat ' + (idx + 1) + ' to open, or random | open for auto-open.', 'dim');
+      setTimeout(bindPostClicks, 50);
     }
   }
 
@@ -521,11 +529,19 @@
       addOutput('No posts available.', 'amber');
       return;
     }
+    var p = term.posts[0];
     if (term.pipeActive) {
       term.pipeBuffer = 1;
-      addOutput('Picked #1...', 'green');
+      addOutput('Picked #1: "' + p.title + '"', 'green');
     } else {
-      openPost(term.posts[0]);
+      addOutputRaw(
+        '  <span class="terminal-post-idx">' + padRight('1', 3) + '</span>'
+        + '<a class="terminal-post-title" data-idx="1">' + escHtml(p.title) + '</a>'
+        + '<span class="terminal-post-date">' + (p.date || '') + '</span>',
+        'green bold'
+      );
+      addOutput('Use cat 1 to open, or latest | open for auto-open.', 'dim');
+      setTimeout(bindPostClicks, 50);
     }
   }
 


### PR DESCRIPTION
## Summary
Change `random` and `latest` behavior: they now display the post title and index in the terminal instead of immediately opening a new tab. Users can click the title or use `cat <number>` to open.

Opening directly is still available via pipe: `random | open` or `latest | open`.

## Before
- `random` → opens a random post in a new tab (surprising)
- `latest` → opens newest post in a new tab

## After
- `random` → shows post title with index, no tab opened
- `latest` → shows newest post with index, no tab opened
- `random | open` → opens a random post in a new tab (explicit intent)
- `latest | open` → opens newest post in a new tab

## Changes
- `assets/js/terminal.js`: `cmdRandom` and `cmdLatest` changed to output formatted post entry with `addOutputRaw` and `bindPostClicks` instead of calling `openPost` directly