### PR TITLE
fix: validate ls page number and fix pipe completion spacing

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -326,6 +326,9 @@
     var beforePartial, partial;
     if (pipeActive) {
       beforePartial = val.substring(0, pipeIdx + 1);
+      if (beforePartial.charAt(beforePartial.length - 1) !== ' ') {
+        beforePartial += ' ';
+      }
       partial = val.substring(pipeIdx + 1).trim();
     } else {
       beforePartial = '';
@@ -442,6 +445,8 @@
 
     var perPage = showAll ? term.posts.length : 10;
     var totalPages = Math.ceil(term.posts.length / perPage);
+    if (page < 1) page = 1;
+    if (page > totalPages) page = totalPages;
     var start = (page - 1) * perPage;
     var end = Math.min(start + perPage, term.posts.length);
     var pagePosts = term.posts.slice(start, end);


### PR DESCRIPTION
## Summary
Two fixes:

1. **ls page number out of range**: `ls 12` when only 4 pages exist now shows page 4 instead of "page 12/4" with no content. Clamped to valid range.

2. **Pipe Tab completion spacing**: `random |open` + Tab now produces `random | open ` instead of `random |open `. Added space-after-pipe check.

## Changes
- `assets/js/terminal.js`: Added page number clamping in cmdLs; added space check in doTabCompletion pipe branch