### PR TITLE
feat: touch screen-zone controls, inactivity auto-open terminal

### DIFF
--- a/_includes/terminal-hero.html
+++ b/_includes/terminal-hero.html
@@ -17,11 +17,6 @@
       <input type="text" id="terminal-input" class="terminal-input" autofocus spellcheck="false" autocomplete="off" aria-label="Terminal input" />
     </div>
   </div>
-  <div id="game-touch-controls" class="game-touch-controls">
-    <button class="touch-btn touch-left" data-key="ArrowLeft" aria-label="Move left">◀</button>
-    <button class="touch-btn touch-fire" data-key=" " aria-label="Shoot">🔥</button>
-    <button class="touch-btn touch-right" data-key="ArrowRight" aria-label="Move right">▶</button>
-  </div>
 </div>
 
 <button id="terminal-return-btn" class="terminal-return-btn{% if page.layout != 'home' %} visible{% endif %}" title="Switch to terminal mode">🖥 Terminal</button>

--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -351,74 +351,12 @@
   margin-top: 2px;
 }
 
-/* ===== GAME TOUCH CONTROLS (mobile only) ===== */
-.game-touch-controls {
-  display: none;
-  position: absolute;
-  bottom: 50px;
-  left: 0;
-  right: 0;
-  padding: 8px 20px;
-  justify-content: space-between;
-  align-items: center;
-  z-index: 10;
-  pointer-events: none;
-}
-
-.game-touch-controls.active {
-  display: flex;
-  pointer-events: auto;
-}
-
-.touch-btn {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  border: 2px solid var(--terminal-border);
-  background: rgba(255,255,255,0.06);
-  color: var(--terminal-text);
-  font-size: 1.3rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  -webkit-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: transparent;
-  touch-action: none;
-}
-
-.touch-btn:active,
-.touch-btn.pressed {
-  background: rgba(255,255,255,0.18);
-  border-color: var(--terminal-green);
-  transform: scale(0.92);
-}
-
-.touch-fire {
-  width: 76px;
-  height: 76px;
-  border-color: var(--terminal-red);
-  color: var(--terminal-red);
-  font-size: 1.6rem;
-}
-
-.touch-fire:active,
-.touch-fire.pressed {
-  border-color: #ff4444;
-  background: rgba(255,60,60,0.15);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .game-touch-controls.active {
-    display: none;
-  }
-}
-
 /* Prevent scroll during game on mobile */
 .terminal-screen.game-active {
   touch-action: none;
 }
+
+/* ===== RESPONSIVE ===== */
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 576px) {

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -17,7 +17,8 @@
     exitBtn: null,
     pipeActive: false,
     pipeBuffer: null,
-    gameActive: false
+    gameActive: false,
+    inactivityTimer: null
   };
 
   /* ===== DATA ===== */
@@ -62,6 +63,28 @@
     registerCommands();
     bindEvents();
     bootSequence();
+    startInactivityWatch();
+  }
+
+  /* ===== INACTIVITY WATCH (auto-open terminal on post pages) ===== */
+  function startInactivityWatch() {
+    if (term.overlay && !term.overlay.classList.contains('hidden')) return;
+    var delay = 10 * 60 * 1000;
+    function resetTimer() {
+      if (!term.overlay.classList.contains('hidden')) return;
+      if (term.inactivityTimer) clearTimeout(term.inactivityTimer);
+      term.inactivityTimer = setTimeout(function () {
+        if (term.overlay.classList.contains('hidden')) {
+          enterTerminalMode();
+          addOutput('Terminal auto-opened after inactivity.', 'dim');
+        }
+      }, delay);
+    }
+    var events = ['mousemove', 'scroll', 'keydown', 'click', 'touchstart'];
+    for (var i = 0; i < events.length; i++) {
+      document.addEventListener(events[i], resetTimer, { passive: true });
+    }
+    resetTimer();
   }
 
   /* ===== COMMAND SYSTEM ===== */
@@ -1122,15 +1145,7 @@
       term.gameActive = false;
       document.removeEventListener('keydown', onKeyDown);
       document.removeEventListener('keyup', onKeyUp);
-      if (touchCtrl) {
-        touchCtrl.classList.remove('active');
-        var btns = touchCtrl.querySelectorAll('.touch-btn');
-        for (var i = 0; i < btns.length; i++) {
-          btns[i].removeEventListener('touchstart', onTouchStart);
-          btns[i].removeEventListener('touchend', onTouchEnd);
-          btns[i].removeEventListener('touchcancel', onTouchEnd);
-        }
-      }
+      removeTouchHandlers();
       if (interval) { clearInterval(interval); interval = null; }
 
       term.screen.innerHTML = savedHTML;
@@ -1143,27 +1158,41 @@
       term.input.focus();
     }
 
-    var touchCtrl = document.getElementById('game-touch-controls');
-    function onTouchStart(e) {
-      var btn = e.currentTarget;
-      g.keys[btn.getAttribute('data-key')] = true;
-      btn.classList.add('pressed');
+    // Touch controls: tap left/right/center of screen
+    var touchKeys = { left: 'ArrowLeft', right: 'ArrowRight', center: ' ' };
+    function onPointerStart(e) {
+      var pt = e.changedTouches ? e.changedTouches[0] : e;
+      var rect = term.screen.getBoundingClientRect();
+      var relX = (pt.clientX - rect.left) / rect.width;
+      g.keys[touchKeys.left] = relX < 0.35;
+      g.keys[touchKeys.right] = relX > 0.65;
+      g.keys[touchKeys.center] = relX >= 0.35 && relX <= 0.65;
       e.preventDefault();
     }
-    function onTouchEnd(e) {
-      var btn = e.currentTarget;
-      g.keys[btn.getAttribute('data-key')] = false;
-      btn.classList.remove('pressed');
+    function onPointerEnd(e) {
+      g.keys[touchKeys.left] = false;
+      g.keys[touchKeys.right] = false;
+      g.keys[touchKeys.center] = false;
       e.preventDefault();
     }
-    if (touchCtrl && ('ontouchstart' in window || navigator.maxTouchPoints > 0)) {
-      touchCtrl.classList.add('active');
-      var btns = touchCtrl.querySelectorAll('.touch-btn');
-      for (var i = 0; i < btns.length; i++) {
-        btns[i].addEventListener('touchstart', onTouchStart, { passive: false });
-        btns[i].addEventListener('touchend', onTouchEnd, { passive: false });
-        btns[i].addEventListener('touchcancel', onTouchEnd, { passive: false });
-      }
+    function addTouchHandlers() {
+      var el = term.screen;
+      el.addEventListener('touchstart', onPointerStart, { passive: false });
+      el.addEventListener('touchend', onPointerEnd, { passive: false });
+      el.addEventListener('touchcancel', onPointerEnd, { passive: false });
+      el.addEventListener('mousedown', onPointerStart);
+      el.addEventListener('mouseup', onPointerEnd);
+    }
+    function removeTouchHandlers() {
+      var el = term.screen;
+      el.removeEventListener('touchstart', onPointerStart);
+      el.removeEventListener('touchend', onPointerEnd);
+      el.removeEventListener('touchcancel', onPointerEnd);
+      el.removeEventListener('mousedown', onPointerStart);
+      el.removeEventListener('mouseup', onPointerEnd);
+    }
+    if ('ontouchstart' in window || navigator.maxTouchPoints > 0) {
+      addTouchHandlers();
     }
 
     document.addEventListener('keydown', onKeyDown);


### PR DESCRIPTION
## Changes\n\n### 1. Mobile touch controls rework\nReplaced unreliable button-based touch controls with screen-zone approach:\n- Tap left 35% of game screen → move left\n- Tap right 35% → move right\n- Tap center 30% → shoot\n- Works on any touch device, zero HTML/CSS dependencies\n- Desktop unaffected (check only activates on touch-capable devices)\n\n### 2. Inactivity auto-open\n- On post pages (terminal hidden), after 10 minutes of no mouse/keyboard/scroll/touch activity, terminal auto-opens\n- Resets on any interaction (mousemove, scroll, keydown, click, touchstart)\n- Skips on homepage (terminal already open)