### PR TITLE
feat: inactivity auto-open on all pages

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -68,10 +68,8 @@
 
   /* ===== INACTIVITY WATCH (auto-open terminal on post pages) ===== */
   function startInactivityWatch() {
-    if (term.overlay && !term.overlay.classList.contains('hidden')) return;
     var delay = 10 * 60 * 1000;
     function resetTimer() {
-      if (!term.overlay.classList.contains('hidden')) return;
       if (term.inactivityTimer) clearTimeout(term.inactivityTimer);
       term.inactivityTimer = setTimeout(function () {
         if (term.overlay.classList.contains('hidden')) {


### PR DESCRIPTION
Now works on homepage too. Timer always runs; only triggers when terminal is hidden.\n\n- Homepage: terminal visible -> timer ticks but does nothing\n- User types `exit` on homepage -> overlay hidden -> next timer fires after 10 min idle -> auto-opens\n- Post pages: same as before\n- Interaction on any page resets the 10 min timer