### PR TITLE
fix: clear interval on game over + auto-return after 8s

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1103,6 +1103,7 @@
 
     function gameOver() {
       g.running = false;
+      if (interval) { clearInterval(interval); interval = null; }
       var out = '<pre style="color:var(--terminal-amber);line-height:1.8;font-size:0.85rem;text-align:center;font-family:monospace">';
       out += '\n\n';
       out += '   ██████   █████  ███    ███ ███████     ██████  ██    ██ ███████ ██████  \n';
@@ -1112,12 +1113,17 @@
       out += '   ██████  ██   ██ ██      ██ ███████     ██████    ████   ███████ ██   ██ \n';
       out += '\n';
       out += '  <span style="color:var(--terminal-green)">Final Score: ' + g.score + '</span>\n';
-      out += '  Press any key to return to terminal\n';
+      out += '  Press any key to skip — auto-return in 8s\n';
       out += '</pre>';
       term.screen.innerHTML = out;
       scrollBottom();
+      var returnTimer = setTimeout(function () {
+        document.removeEventListener('keydown', _waitKey);
+        cleanup();
+      }, 8000);
       document.addEventListener('keydown', function _waitKey() {
         document.removeEventListener('keydown', _waitKey);
+        clearTimeout(returnTimer);
         cleanup();
       });
     }


### PR DESCRIPTION
**Memory leak fix**\ngameOver() now calls clearInterval immediately. Before this, setInterval kept running\nat 80ms doing nothing but checking `if (!g.running) return`, keeping a large closure\nchain (g, savedHTML, inputLine, term, etc.) alive until user pressed a key.\n\n**UX**\nAfter game over: auto returns to terminal prompt after 8 seconds.\nPress any key to skip the wait.