### PR TITLE
fix: enemies now appear after 240ms instead of 3.8s

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -953,7 +953,7 @@
       bullets: [], enemies: [], enemyBullets: [],
       hp: 5, invincible: 0, score: 0, frame: 0,
       keys: {}, running: true,
-      spawnCounter: 0, wave: 1, waveFlash: 0, won: false
+      spawnCounter: 45, wave: 1, waveFlash: 0, won: false
     };
 
     function spaces(n) {


### PR DESCRIPTION
spawnCounter was 0, so first spawn waited for spawnRate (48) frames = 3.8s of empty screen.\nNow initialized to 45, first enemy appears after 3 frames = 240ms.