### PR TITLE
feat: big countdown as CSS overlay, no layout breakage

### DIFF
--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -97,6 +97,7 @@
 .terminal-screen {
   flex: 1;
   overflow-y: auto;
+  position: relative;
   padding: 16px;
   font-family: "SF Mono", Monaco, "Cascadia Code", "Fira Code", "Courier New", monospace;
   font-size: 0.85rem;

--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1030,30 +1030,20 @@
       // Separator + grid
       out += '<span style="color:var(--terminal-amber)">├' + dashes + '┤</span>\n';
       for (var y = 0; y < H; y++) {
-        out += '<span style="color:var(--terminal-amber)">│</span>';
-        if (g.countdown > 0 && !cdBlink) {
-          var cdBoxW = cdText.length + 4;
-          var cdTopY = Math.floor(H / 2) - 1;
-          var cdLeft = Math.floor((W - cdBoxW) / 2);
-          if (y === cdTopY) {
-            out += spaces(cdLeft) + '╔' + new Array(cdBoxW - 1).join('═') + '╗' + spaces(Math.max(0, W - cdLeft - cdBoxW));
-          } else if (y === cdTopY + 1) {
-            out += spaces(cdLeft) + '║ ' + cdText + ' ║' + spaces(Math.max(0, W - cdLeft - cdBoxW));
-          } else if (y === cdTopY + 2) {
-            out += spaces(cdLeft) + '╚' + new Array(cdBoxW - 1).join('═') + '╝' + spaces(Math.max(0, W - cdLeft - cdBoxW));
-          } else {
-            out += grid[y].join('');
-          }
-        } else {
-          out += grid[y].join('');
-        }
-        out += '<span style="color:var(--terminal-amber)">│</span>\n';
+        out += '<span style="color:var(--terminal-amber)">│</span>' + grid[y].join('') + '<span style="color:var(--terminal-amber)">│</span>\n';
       }
       out += '<span style="color:var(--terminal-amber)">└' + dashes + '┘</span>\n';
       out += '<span style="color:var(--terminal-comment)"> [←][→] move  [space] shoot  [q] quit</span>';
       out += '</pre>';
       term.screen.innerHTML = out;
       scrollBottom();
+
+      if (g.countdown > 0 && !cdBlink) {
+        var overlay = document.createElement('div');
+        overlay.textContent = cdText;
+        overlay.style.cssText = 'position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);font-size:3rem;color:var(--terminal-cyan);font-weight:bold;font-family:monospace;z-index:10;pointer-events:none';
+        term.screen.appendChild(overlay);
+      }
     }
 
     function update() {


### PR DESCRIPTION
- HUD (hearts/score/wave) shows normally during countdown\n- Grid borders are perfect (no CSS font-size inside the <pre>)\n- Countdown text (3, 2, 1, GO!) renders as a position:absolute <div> with 3rem font, centered on the game area\n- GO! blink still works (overlay removed every other 2 frames)\n- Ship is visible in the grid behind the overlay