### PR TITLE
fix: wrap Go template syntax in {% raw %} to fix Liquid warnings

### DIFF
--- a/_posts/2022-12-29-gitlab-kubernetes-runner.md
+++ b/_posts/2022-12-29-gitlab-kubernetes-runner.md
@@ -135,6 +135,7 @@ kubectl create secret generic kubeconfigs \
   --from-file=<path-to-kubeconfigs>
 ```
 
+{% raw %}
 ```yaml
 runners:
   config: |
@@ -149,9 +150,11 @@ runners:
           [runners.kubernetes.volumes.secret.items]
             "kubeconfigs" = "config"
 ```
+{% endraw %}
 
 # Final values.yaml
 
+{% raw %}
 ```yaml
 image:
   registry: registry.gitlab.com
@@ -203,3 +206,4 @@ runners:
   runUntagged: false
   secret: gitlab-runner-secret
 ```
+{% endraw %}

--- a/_posts/2024-08-15-integration-of-k8s-with-external-vault.md
+++ b/_posts/2024-08-15-integration-of-k8s-with-external-vault.md
@@ -82,6 +82,7 @@ EOF
 
 2. Create new kubernetes auth method
 
+{% raw %}
 ```bash
 export VAULT_ADDR=http://0.0.0.0:8200
 vault auth enable kubernetes
@@ -125,6 +126,7 @@ vault write auth/kubernetes/role/devweb-app2 \
      policies=devwebapp \
      ttl=24h
 ```
+{% endraw %}
 
 ## Create two exmaple applications
 


### PR DESCRIPTION
Two posts contain Go template syntax that Liquid tried to parse:\n- _posts/2022-12-29-gitlab-kubernetes-runner.md: {{.Release.Namespace}} in YAML\n- _posts/2024-08-15-integration-of-k8s-with-external-vault.md: {{ .data.token }} in bash\n\nFixed with {% raw %}...{% endraw %} wrapping the code blocks. No content was removed (the 2024 post had accidentally lost the vault policy and role creation sections in the working tree — restored from HEAD).