### PR TITLE
fix: add 500ms cooldown before accepting key to skip end screen

### DIFF
--- a/assets/js/terminal.js
+++ b/assets/js/terminal.js
@@ -1251,7 +1251,13 @@
       out += '</pre>';
       term.screen.innerHTML = out;
       scrollBottom();
-      function waitKey() {
+
+      // Cooldown: ignore key events for 500ms to absorb held-key auto-repeat
+      var cooldown = true;
+      setTimeout(function () { cooldown = false; }, 500);
+
+      function waitKey(e) {
+        if (cooldown) return;
         document.removeEventListener('keydown', waitKey);
         clearTimeout(returnTimer);
         cleanup();


### PR DESCRIPTION
Problem: when the game ends, held keys from gameplay trigger browser auto-repeat keydown events, which immediately call the 'Press any key to skip' handler. The end screen is skipped before the player can see it.\n\nFix: added a cooldown flag. Keydown events during the first 500ms are silently dropped. After cooldown expires, normal behavior resumes.