### PR TITLE
perf: inline critical terminal overlay CSS to prevent flash

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -64,6 +64,21 @@
   {% include cloudflare_analytics.html %}
   {% include mathjax.html %}
 
+  <style>
+    #terminal-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 99999;
+      background: #0d1117;
+    }
+    #terminal-overlay.hidden {
+      display: none;
+    }
+  </style>
+
   {% if layout.common-ext-css %}
     {% for css in layout.common-ext-css %}
       {% include ext-css.html css=css %}


### PR DESCRIPTION
On slow networks, the terminal overlay CSS (terminal.css) loads after the HTML renders, causing a flash of blog content before the overlay gets position:fixed + background.\n\nFix: inline the 7 critical CSS rules directly in <head> as a <style> tag before any external stylesheets. From the first paint, the overlay covers the viewport. The rules match terminal.css exactly, so there's no conflict when it loads.