### PR TITLE
fix: move terminal overlay to top of <body> to prevent content flash

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -29,6 +29,8 @@ common-js:
 <body>
   {% include gtm_body.html %}
 
+  {% include terminal-hero.html %}
+
   {% include nav.html %}
 
   {{ content }}
@@ -36,8 +38,6 @@ common-js:
   {% include footer.html %}
 
   {% include footer-scripts.html %}
-
-  {% include terminal-hero.html %}
 
 </body>
 </html>


### PR DESCRIPTION
Root cause: browser paints incrementally as HTML parses. terminal-hero.html was at the bottom of body, after content. Blog content was rendered and painted before the overlay element existed in the DOM.

Fix: move terminal-hero.html to be the first element after body opens. The overlay uses position:fixed, so it is out of flow and does not affect subsequent layout. Combined with the inline critical CSS from PR #92, the overlay now covers the viewport before any content renders.